### PR TITLE
Adding ALL the rest scenarios

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# git_source(:github) {|repo_name|
+# 'https://github.com/barbaracabral/bravi-test'}
+
+# gem "rails"
+#gem "rack-test"
+#gem 'json'
+gem 'cucumber'
+gem 'httparty'
+gem 'rspec'
+gem 'pry'
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,58 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backports (3.10.3)
+    builder (3.2.3)
+    coderay (1.1.2)
+    cucumber (3.0.1)
+      builder (>= 2.1.2)
+      cucumber-core (~> 3.0.0)
+      cucumber-expressions (~> 4.0.3)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (~> 1.3)
+      gherkin (~> 4.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (3.0.0)
+      backports (>= 3.8.0)
+      cucumber-tag_expressions (>= 1.0.1)
+      gherkin (>= 4.1.3)
+    cucumber-expressions (4.0.4)
+    cucumber-tag_expressions (1.0.1)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
+    gherkin (4.1.3)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
+    method_source (0.9.0)
+    multi_json (1.12.2)
+    multi_test (0.1.2)
+    multi_xml (0.6.0)
+    pry (0.11.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cucumber
+  httparty
+  pry
+  rspec
+
+BUNDLED WITH
+   1.16.0

--- a/features/specifications/accounts.feature
+++ b/features/specifications/accounts.feature
@@ -1,0 +1,18 @@
+@accounts
+Feature: CRUD actions to manipulate accounts
+In order to manipulate the accounts
+As an user
+I want to do the CRUD actions
+
+Background:
+  Given I am on the accounts api page
+
+@inserting_a_account
+Scenario: Inserting a new account
+  When I insert a new account
+  Then I receive the code "200"
+
+@inserting_a_account_already_created
+Scenario: Inserting a new account
+  When I insert an account already created
+  Then I receive the code "409" and the message "O e-mail informado, ja está cadastrado!"

--- a/features/specifications/books.feature
+++ b/features/specifications/books.feature
@@ -1,0 +1,36 @@
+@books
+Feature: CRUD actions to manipulate books
+In order to manipulate the books
+As an user
+I want to do the CRUD actions
+
+Background:
+  Given I am on the books api page
+
+@inserting_a_book
+Scenario: Inserting a new book
+  When I insert a new book
+  Then I receive the code "200"
+
+@inserting_a_book_already_created
+Scenario: Inserting a book already created
+  When I insert a book already created
+  Then I receive the code "409" and the message "O livro com título Dom Casmurro, ja está cadastrado."
+
+@search_all_books
+Scenario: Not Enough segments to GET a list of books without parameter
+  When I GET a list of books without parameter
+  Then I receive the code "200"
+  And I see the list of the books
+
+@valid_search_by_author
+Scenario: GET a list of books searching by Author
+ When I GET the books related to the author "Machado de Assiss"
+ Then I receive the code "200"
+ And I see the list of the books
+
+@invalid_search_by_author
+Scenario: No results found to GET a list of books searching by Author
+  When I GET the books related to the author "Invalid Author"
+  Then I receive the code "200"
+  And I don't see any book on the list

--- a/features/specifications/login.feature
+++ b/features/specifications/login.feature
@@ -1,0 +1,20 @@
+@login
+Feature: Acess the API
+
+@invalid_json
+Scenario: Login as an user inserting an invalid json
+  Given I am on the books api token page
+  When I inform the wrong login data
+  Then I receive the code "400" and the message "JSON Inválido"
+
+@invalid_email
+Scenario: Login as an user inserting an invalid email
+  Given I am on the books api token page
+  When I inform an invalid email
+  Then I receive the code "409" and the message "Usuário e/ou senha inválidos."
+
+@valid_email
+Scenario: Login as an user inserting an valid email
+  Given I am on the books api token page
+  When I inform a valid email
+  Then I receive the my access token

--- a/features/step_definitions/accounts_step.rb
+++ b/features/step_definitions/accounts_step.rb
@@ -1,0 +1,41 @@
+
+Given("I am on the accounts api page") do
+ @url_token = 'https://nbooks.herokuapp.com/api/accounts'
+end
+
+When("I insert a new account") do
+  values = {
+    "name": "Bárbara",
+    "email": "barbaracabral#{Random.rand(1..10)*121}@gmail.com",
+    "password": "123456"
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => values.to_json,
+    :headers => {:content_type => 'application/json'}
+  )
+end
+
+When("I insert an account already created") do
+  values = {
+    "name": "Bárbara",
+    "email": "barbaracabral@gmail.com",
+    "password": "123456"
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => values.to_json,
+    :headers => {:content_type => 'application/json'}
+  )
+end
+
+When("I get an account already created") do
+  query = {
+    "email" => "barbaracabral@gmail.com"
+  }
+  @result = NBooksAPI.get(
+    @url_token.to_str,
+    :query => query,
+    :headers => {:content_type => 'application/json'}
+  )
+end

--- a/features/step_definitions/books_steps.rb
+++ b/features/step_definitions/books_steps.rb
@@ -1,0 +1,63 @@
+Given("I am on the books api page") do
+  @url_token = 'https://nbooks.herokuapp.com/api/books'
+end
+
+When("I insert a new book") do
+  values = {
+    "title": "Dom Casmurro #{Random.rand(1..10)*121}",
+    "author": "Machado de Assiss #{Random.rand(1..10)*121}",
+    "tags": [
+      "Romance",
+      "Literatura"
+    ]
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => values.to_json,
+    :headers => {:content_type => 'application/json', ACCESS_TOKEN: @access_token }
+  )
+end
+
+When("I insert a book already created") do
+  values = {
+    "title": "Dom Casmurro",
+    "author": "Machado de Assiss",
+    "tags": [
+      "Romance",
+      "Literatura"
+    ]
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => values.to_json,
+    :headers => {:content_type => 'application/json', ACCESS_TOKEN: @access_token }
+  )
+end
+
+
+When("I GET a list of books without parameter") do
+  @result = NBooksAPI.get(
+    @url_token.to_str,
+    :headers => {:content_type => 'application/json', ACCESS_TOKEN: @access_token }
+  )
+end
+
+When("I GET the books related to the author {string}") do |string|
+  query = {
+    "author" => string,
+    "title": "Dom Casmurro"
+  }
+  @result = NBooksAPI.get(
+    @url_token.to_str,
+    :query => query,
+    :headers => {:content_type => 'application/json', ACCESS_TOKEN: @access_token }
+  )
+end
+
+Then("I see the list of the books") do
+  expect(@result.parsed_response.count).not_to eq 0
+end
+
+Then("I don't see any book on the list") do
+  expect(@result.parsed_response.count).to eq 0
+end

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -1,0 +1,8 @@
+Then("I receive the code {string} and the message {string}") do |code, message|
+  expect(@result.response.code).to eq code
+  expect(@result.parsed_response['message']).to eq message
+end
+
+Then("I receive the code {string}") do |code|
+  expect(@result.response.code).to eq code
+end

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -1,0 +1,40 @@
+Given("I am on the books api token page") do
+  @url_token = 'https://nbooks.herokuapp.com/api/token'
+end
+
+When("I inform the wrong login data") do
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :values => {:email => 'eu@papito.io', :password => 'secret' },
+    :headers => {:content_type => 'application/json' }
+  )
+end
+
+When("I inform an invalid email") do
+  body = {
+  "email": "barbaracabral@qualquercoisa.com",
+  "password": "123456"
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => body.to_json,
+    :headers => {:content_type => 'application/json' }
+  )
+end
+
+When("I inform a valid email") do
+  body = {
+  "email": "barbaracabral@gmail.com",
+  "password": "123456"
+  }
+  @result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => body.to_json,
+    :headers => {:content_type => 'application/json' }
+  )
+end
+
+Then("I receive the my access token") do
+  @access_token = @result.parsed_response['account_token']
+  expect(@result.response.code).to eq "200"
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,11 @@
+require 'cucumber'
+require 'httparty'
+require 'rspec'
+require 'json'
+require 'pry'
+
+class NBooksAPI
+  include HTTParty
+  base_uri 'https://nbooks.herokuapp.com/'
+  default_params output: 'json'
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,24 @@
+Before('@books') do
+  @url_token = 'https://nbooks.herokuapp.com/api/token'
+  body = {
+  "email": "barbaracabral@gmail.com",
+  "password": "123456"
+  }
+  result = NBooksAPI.post(
+    @url_token.to_str,
+    :body => body.to_json,
+    :headers => {:content_type => 'application/json' }
+  )
+  @access_token = result.parsed_response['account_token']
+  puts
+end
+
+Before('@inserting_a_account') do
+  @url_token = 'https://nbooks.herokuapp.com/api/accounts'
+
+  result = NBooksAPI.delete(
+    @url_token.to_str,
+    :body => {:email => "barbaracabral@gmail.com"},
+    :headers => {:content_type => 'application/json' }
+  )
+end


### PR DESCRIPTION
```cucumber
@accounts
Feature: CRUD actions to manipulate accounts
In order to manipulate the accounts
As an user
I want to do the CRUD actions

Background:
  Given I am on the accounts api page

@inserting_a_account
Scenario: Inserting a new account
  When I insert a new account
  Then I receive the code "200"

@inserting_a_account_already_created
Scenario: Inserting a new account
  When I insert an account already created
  Then I receive the code "409" and the message "O e-mail informado, ja está cadastrado!"

@books
Feature: CRUD actions to manipulate books
In order to manipulate the books
As an user
I want to do the CRUD actions

Background:
  Given I am on the books api page

@inserting_a_book
Scenario: Inserting a new book
  When I insert a new book
  Then I receive the code "200"

@inserting_a_book_already_created
Scenario: Inserting a book already created
  When I insert a book already created
  Then I receive the code "409" and the message "O livro com título Dom Casmurro, ja está cadastrado."

@search_all_books
Scenario: Not Enough segments to GET a list of books without parameter
  When I GET a list of books without parameter
  Then I receive the code "200"
  And I see the list of the books

@valid_search_by_author
Scenario: GET a list of books searching by Author
 When I GET the books related to the author "Machado de Assiss"
 Then I receive the code "200"
 And I see the list of the books

@invalid_search_by_author
Scenario: No results found to GET a list of books searching by Author
  When I GET the books related to the author "Invalid Author"
  Then I receive the code "200"
  And I don't see any book on the list

@login
Feature: Acess the API

@invalid_json
Scenario: Login as an user inserting an invalid json
  Given I am on the books api token page
  When I inform the wrong login data
  Then I receive the code "400" and the message "JSON Inválido"

@invalid_email
Scenario: Login as an user inserting an invalid email
  Given I am on the books api token page
  When I inform an invalid email
  Then I receive the code "409" and the message "Usuário e/ou senha inválidos."

@valid_email
Scenario: Login as an user inserting an valid email
  Given I am on the books api token page
  When I inform a valid email
  Then I receive the my access token

```